### PR TITLE
add `${tag}` placeholder for path in fluent v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,36 @@ $ td-agent-gem install fluent-plugin-google-cloud-storage-out
 </match>
 ```
 
+#### `${tag}` and  `${tag[n]}` Placeholder Support For Fluent v1
+```
+<match test.*>
+    @type google_cloud_storage_out
+    service_account_json_key_path /etc/td-agent/client_secrets.json
+    bucket_id access-log
+    path_suffix .json
+    path "${tag}/%Y-%m/%d/%H%M_${unique}.json"
+    # path "${tag[1]}/%Y-%m/%d/%H%M_${unique}.json"
+    add_log_suffix false
+    unique_strategy increment
+    format json
+
+    <buffer tag,time>
+        @type file
+        path /var/fluentd-buffer/test.*.buffer
+        timekey 1d
+    </buffer>
+</match>
+```
+
 | parameter | description |
 | ---- | ---- |
 | service_account_json_key_path | Absolute Path to json key |
 | bucket_id | GCS Bucket ID to Store |
-| path | Path to save, if you use `/`, that will resolve to directory. And if path is including time format , then rotate by minum unit. Moreover, you can include ${unique}, that is to replace token with unique key|
+| path | Path to save, if you use `/`, that will resolve to directory. And if path is including time format , then rotate by minum unit. Moreover, you can include `${unique}`, that is to replace token with unique key . You can using path including tag as directory with `${tag}` placeholder |
 | unique_strategy | you can choice chunk_id, timestamp and inctement |
 | unique_format | Now, if you choiced `timestamp` to unique_strategy, then you can ccustom timestampformat. Default format is `%Y%m%d%H%M%S%L` |
 | format |  |
+| add_log_suffix | Add log suffix for file, default `true` |
 | compress | gzip or nil |
 
 #### Bucket


### PR DESCRIPTION
* add `${tag}` placeholder for path for fluent v1
* add parameter add_log_suffix
* fix bug when fluentd shutdown


#### `${tag}` and  `${tag[n]}` Placeholder Support For Fluent v1
```
<match test.*>
    @type google_cloud_storage_out
    service_account_json_key_path /etc/td-agent/client_secrets.json
    bucket_id access-log
    path_suffix .json
    path "${tag}/%Y-%m/%d/%H%M_${unique}.json"
    # path "${tag[1]}/%Y-%m/%d/%H%M_${unique}.json"
    add_log_suffix false
    unique_strategy increment
    format json

    <buffer tag,time>
        @type file
        path /var/fluentd-buffer/test.*.buffer
        timekey 1d
    </buffer>
</match>
```
